### PR TITLE
Support local builds for a single version and redirect root to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ python run.py build-docs
 
 Options:
 - `--skip-build` (`-s`): Skip building before generating docs
-- `--local` (`-l`): Build local, single version
+- `--local` (`-l`): Build documentation locally for a single version (skips multi-version build)
 
 The documentation can be accessed locally by serving the docs/build/html/ folder:
 ```sh

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -1259,7 +1259,7 @@ The project includes a ``run.py`` script with several useful commands:
   navigation dropdown; run ``git fetch --tags`` locally before building)
 
   - ``--skip-build`` (``-s``): Skip building the package before generating docs
-  - ``--local`` (``-l``): Build local, single version
+  - ``--local`` (``-l``): Build documentation locally for a single version (skips multi-version build)
 
 .. note::
    When releasing a new version, update ``switcher.json`` in ``docs/source/_static/`` 

--- a/run.py
+++ b/run.py
@@ -297,7 +297,7 @@ def build_mo():
 
 
 def create_root_redirect(build_output: str) -> None:
-    """Create an index.html at the root that redirects to /latest/."""
+    """Create an index.html in the versioned HTML build output root that redirects to /latest/."""
     index_path = os.path.join(build_output, 'index.html')
     redirect_html = """<!DOCTYPE html>
 <html>


### PR DESCRIPTION
## Description
This PR adds support for running local builds against a single documentation version, simplifying development and testing workflows. It also introduces a root-level redirect so that the site’s base URL automatically points to the latest available version, ensuring users always land on the most up-to-date content.

## Type of change
- [x] Build feature optimization

## Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [ ] I have added a note to CHANGELOG.md describing my changes
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published