### PR TITLE
Bump pytest to 9.0.3 for CVE-2025-71176

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pre-commit==4.2.0
 pydata-sphinx-theme==0.16.1
 pygetwindow==0.0.9
 pylint==3.3.4
-pytest==8.3.4
+pytest==9.0.3
 sphinx==8.1.3
 sphinx-multiversion==0.2.4
 sphinx-autodoc-typehints==3.0.1


### PR DESCRIPTION
## Description
Bump pytest from 8.3.4 to 9.0.3 in `requirements.txt` to pick up the patched tmpdir handling for CVE-2025-71176 / GHSA-6w46-j5rx-g56g.

This is a low-risk dependency-only change and updates the single pinned pytest version used by this branch.

Fixes # (issue)
N/A - addresses the Dependabot security alert "pytest has vulnerable tmpdir handling", not GitHub issue #2 in this repository.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [ ] I have added a note to CHANGELOG.md describing my changes
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Testing
- `python run.py build`
- `python run.py lint` *(repo baseline is already non-clean outside this change)*
- `python run.py test` *(repo baseline fails on macOS due `ModuleNotFoundError: winreg` before this dependency update is involved)*

## Additional Notes
- Changed files: `requirements.txt`
- Diff summary: `pytest==8.3.4` -> `pytest==9.0.3`
- Impact: removes the vulnerable pytest pin called out by CVE-2025-71176 / GHSA-6w46-j5rx-g56g.
