### PR TITLE
Bump GitPython to 3.1.49 to fix CVE-2026-44244

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ black==26.3.1
 build==1.2.2.post1
 coverage==7.6.12
 docopt==0.6.2
-gitpython==3.1.47
+gitpython==3.1.49
 packaging==24.2
 pathspec==1.0.4
 polib==1.2.0


### PR DESCRIPTION
## Summary
- Bumps `gitpython` from `3.1.47` to `3.1.49` in `requirements.txt`.
- Pulls in the upstream fix for **CVE-2026-44244** (GitPython `<=3.1.48`).
- This addresses a config-injection issue in `GitConfigParser.set_value()` where CR/LF in untrusted values can poison `.git/config` and set attacker-controlled `core.hooksPath`.

## Security Context
- Vulnerable versions may allow persistent repository config poisoning when caller-controlled values are passed into `config_writer().set_value(...)` without sanitization.
- In affected workflows, this can redirect Git hook execution to attacker-controlled scripts during subsequent Git operations.
- Upgrading to `3.1.49` removes exposure to this dependency-level issue in this service.

## Scope of Change
- Runtime dependency patch only (`requirements.txt`).
- No application logic changes.

## Validation
- Verified diff only changes: `gitpython==3.1.47` -> `gitpython==3.1.49`.
- Version target matches the patched release published for CVE-2026-44244.